### PR TITLE
refactor: 배포 시 빌드 설정을 위한 파일 수정

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.js", "src/**/*.jsx"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cp ./config/tsconfig.app.json ./config/tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
+    "build": "cp ./config/tsconfig.app.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cp ./config/tsconfig.json ./tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
+    "build": "cp ./config/tsconfig.app.json ./config/tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
+    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
-    "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -b && vite build",
+    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production tsc -p ./config/tsconfig.json && vite build",
+    "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",
     "test": "cross-env NODE_ENV=test jest"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cp ./config/tsconfig.app.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
+    "build": "cp ./config/tsconfig.app.json ./tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production tsc -p ./config/tsconfig.json && vite build",
+    "build": "cp ./config/tsconfig.json ./tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "cross-env NODE_ENV=development VITE_APP_ENV=development vite",
-    "build": "cp ./config/tsconfig.app.json ./tsconfig.json && cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
+    "build": "cross-env NODE_ENV=production VITE_APP_ENV=production tsc -b && vite build",
     "build:dev": "cross-env NODE_ENV=development VITE_APP_ENV=development tsc -p ./config/tsconfig.json && vite build",
     "lint": "cross-env NODE_ENV=development eslint .",
     "preview": "cross-env NODE_ENV=production vite preview",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,17 +6,23 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+
+    /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+
+    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
+
+    /* Paths */
     "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> #8 

## 📝작업 내용

> vercel 빌드 오류로 인한 파일 수정입니다.
> 지금 초기 파일만 있는 관계로.. 타입스크립트 컴파일 오류 때문에 빌드가 되지 않는 이슈가 있었습니다.
> 그래서 패키지 파일 빌드 스크립트를 타입스크립트 컴파일 안하고 실행하는 걸로 수정하였습니다.
> 나중에 코드 작성 후 배포시에는 다시 컴파일 코드 작성 예정입니다!!!