### PR TITLE
ci/cd: 배포 워크 플로우 수정 및 프리뷰 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.repository == 'KBE5_MAIDLAB_FE/KBE5_MAIDLAB_FE'
+    if: github.repository == 'Kernel360/KBE5_MAIDLAB_FE'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,14 +2,21 @@ name: Deploy
 
 on:
   push:
-    branches: ['dev']
+    branches:
+      - dev
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'KBE5_MAIDLAB_FE/KBE5_MAIDLAB_FE'
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -24,10 +31,12 @@ jobs:
         run: npm run build
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v20
+        uses: amondnet/vercel-action@v25
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           working-directory: ./
-          vercel-args: '--prod'
+          vercel-args: '--prod --force'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-comment: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
       - '**.md'
       - '.github/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,7 +10,6 @@ on:
       - dev
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,62 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - dev
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Vercel Preview
+        id: deploy
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          working-directory: ./
+          vercel-args: '--preview --force'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-comment: true
+
+      - name: Comment PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const previewUrl = process.env.VERCEL_URL;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `🚀 프리뷰 배포가 완료되었습니다!\n\n🔗 프리뷰 URL: https://${previewUrl}`
+            });
+        env:
+          VERCEL_URL: ${{ steps.deploy.outputs.preview-url }}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #7 

## 📝작업 내용

### 1. 배포 워크플로우 업데이트

```
name: Deploy
on:
  push:
    branches: ['dev']
    paths-ignore:
      - '**.md'
      - '.github/**'
jobs:
  build:
    runs-on: ubuntu-latest
    if: github.repository == 'KBE5_MAIDLAB_FE/KBE5_MAIDLAB_FE'
```
* 메인 organization 저장소에서만 배포가 실행되도록 조건 추가
* 문서나 워크플로우 파일 변경 시 불필요한 배포를 방지하기 위한 paths-ignore 추가


### 2. 프리뷰 배포 설정 파일 추가
* 포크된 저장소에서 오는 PR에 대해서만 프리뷰 배포가 실행되도록 조건 추가
* Vercel이 포크와 연결되어 있어도 배포가 작동하도록 --force 플래그 추가
* PR에 배포 상태를 자동으로 코멘트하기 위한 GitHub 코멘트 설정 추가