### PR TITLE
hotfix/fe/#73 adminProtectRoute 생성

### DIFF
--- a/src/components/common/ProtectedRoute/AdminProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute/AdminProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAdminAuth } from '@/hooks/useAdminAuth';
+import { ROUTES } from '@/constants';
+
+interface AdminProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+const AdminProtectedRoute: React.FC<AdminProtectedRouteProps> = ({ children }) => {
+  const { isAuthenticated } = useAdminAuth();
+
+  if (!isAuthenticated) {
+    return <Navigate to={ROUTES.ADMIN.LOGIN} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminProtectedRoute;

--- a/src/components/common/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute/ProtectedRoute.tsx
@@ -44,9 +44,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
         ? ROUTES.CONSUMER.MYPAGE
         : userType === 'MANAGER'
           ? ROUTES.MANAGER.MYPAGE
-          : userType === 'ADMIN'
-            ? ROUTES.ADMIN.DASHBOARD
-            : ROUTES.LOGIN;
+          : ROUTES.LOGIN;
 
 
     return <Navigate to={defaultPage} replace />;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export { LoadingSpinner } from './LoadingSpinner/LoadingSpinner';
 export { ProtectedRoute } from './ProtectedRoute/ProtectedRoute';
 export { ToastContainer } from './ToastContainer/ToastContainer';
+export { default as AdminProtectedRoute } from './ProtectedRoute/AdminProtectedRoute';

--- a/src/pages/admin/AdminLogin.tsx
+++ b/src/pages/admin/AdminLogin.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Box, Button, Container, TextField, Typography, Paper, Alert } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { useAdminAuth } from '@/hooks/useAdminAuth';
+import React from 'react';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   padding: theme.spacing(4),
@@ -38,6 +39,18 @@ const AdminLogin = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
+  // 인증 성공 시 자동 이동
+  React.useEffect(() => {
+    if (isAuthenticated) {
+      navigate('/admin', { replace: true });
+    }
+  }, [isAuthenticated, navigate]);
+
+  // 인증된 상태면 아무것도 렌더링하지 않음(무한루프 방지)
+  if (isAuthenticated) {
+    return null;
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -49,15 +62,11 @@ const AdminLogin = () => {
         password: password,
       });
 
-      // 로그인 성공시 페이지 이동
-      if (result.success) {
-        navigate('/admin');
-      } else {
-        // 로그인 실패시 에러 표시 (이미 토스트로 표시되지만 추가로 표시하고 싶다면)
+      // 로그인 실패시 오류 출력
+      if (!result.success) {
         setError(result.error || '로그인에 실패했습니다.');
       }
     } catch (error) {
-      // 예상치 못한 에러 처리
       setError('로그인 중 오류가 발생했습니다.');
       console.error('Login error:', error);
     }

--- a/src/routes/admin.tsx
+++ b/src/routes/admin.tsx
@@ -1,6 +1,6 @@
 import { Route } from 'react-router-dom';
 import { ROUTES } from '@/constants';
-import { ProtectedRoute } from '@/components/common';
+import { AdminProtectedRoute } from '@/components/common';
 import {
   AdminLogin,
   AdminLayout,
@@ -20,7 +20,6 @@ import {
   AdminEventDetail,
   Dashboard,
 } from '@/pages';
-//import AdminSettlementDetail from '@/pages/admin/SettlementDetail';
 
 export const AdminRoutes = () => (
   <>
@@ -28,9 +27,9 @@ export const AdminRoutes = () => (
     <Route
       path={ROUTES.ADMIN.DASHBOARD}
       element={
-        <ProtectedRoute requiredUserType="ADMIN">
+        <AdminProtectedRoute>
           <AdminLayout />
-        </ProtectedRoute>
+        </AdminProtectedRoute>
       }
     >
       <Route path="users" element={<AdminUserList />} />


### PR DESCRIPTION

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#73 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 어드민 로그인시 로그인 화면으로 강제이동되던 버그 수정

useAuth를 사용하는 ProtectRoute는 admin의 권한을 인식하지 못해 어드민로그인을 해도 로그인이 안된것으로 판단 할 수 있고, 일반 로그인 화면으로 이동되는 것으로 짐작함. 
따라서 admin용 useAuth를 만들고 ProtectedRoute 또한 admin용으로 새로 만들어 어드민페이지에 적용하도록 함

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
