### PR TITLE
refactor: pages/consumer 인터페이스 types에 따로 분리

### DIFF
--- a/src/pages/consumer/ConsumerReviewRegister.tsx
+++ b/src/pages/consumer/ConsumerReviewRegister.tsx
@@ -4,16 +4,7 @@ import { useReservation } from '@/hooks/domain/useReservation';
 import { ROUTES } from '@/constants';
 import { LENGTH_LIMITS } from '@/constants/validation';
 import type { ReviewRegisterRequest } from '@/types/reservation';
-
-// 선호도 타입 정의
-type PreferenceType = 'LIKE' | 'BLACKLIST' | 'NONE';
-
-// 리뷰 폼 데이터 타입 정의
-interface ReviewFormData {
-  rating: number;
-  comment: string;
-  preference: PreferenceType;
-}
+import type { PreferenceType, ReviewFormData } from '@/types/consumer';
 
 // 별점 컴포넌트
 const RatingStars: React.FC<{

--- a/src/pages/consumer/MyPage.tsx
+++ b/src/pages/consumer/MyPage.tsx
@@ -14,14 +14,8 @@ import {
 } from 'lucide-react';
 import { useConsumer } from '@/hooks/domain/useConsumer';
 import { useToast } from '@/hooks/useToast';
-import type { ConsumerMyPageResponse } from '@/types/consumer';
+import type { ConsumerMyPageResponse, MenuItemProps } from '@/types/consumer';
 import { ROUTES } from '@/constants';
-
-interface MenuItemProps {
-  icon: React.ReactNode;
-  title: string;
-  onClick: () => void;
-}
 
 const MenuItem: React.FC<MenuItemProps> = ({ icon, title, onClick }) => (
   <button

--- a/src/pages/consumer/Profile.tsx
+++ b/src/pages/consumer/Profile.tsx
@@ -3,16 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, User } from 'lucide-react';
 import { useConsumer } from '@/hooks/domain/useConsumer';
 import { ROUTES } from '@/constants';
-
-interface ProfileData {
-  name: string;
-  phoneNumber: string;
-  birth: string;
-  gender: 'MALE' | 'FEMALE';
-  address: string;
-  detailAddress: string;
-  profileImage: string | undefined;
-}
+import type { ProfileData } from '@/types/consumer';
 
 const DEFAULT_PROFILE_IMAGE = '/default-profile.png';
 

--- a/src/pages/consumer/ProfileEdit.tsx
+++ b/src/pages/consumer/ProfileEdit.tsx
@@ -4,20 +4,10 @@ import { ArrowLeft, Upload, User, Eye, EyeOff, Lock } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { useConsumer } from '@/hooks/domain/useConsumer';
 import { useAuth } from '@/hooks/useAuth';
-import type { ConsumerProfileUpdateRequest } from '@/types/consumer';
+import type { ConsumerProfileUpdateRequest, ProfileData } from '@/types/consumer';
 import { ROUTES } from '@/constants';
 import { uploadToS3 } from '@/utils/s3';
 import { validatePassword } from '@/utils/validation';
-
-interface ProfileData {
-  name: string;
-  phoneNumber: string;
-  birth: string;
-  gender: 'MALE' | 'FEMALE';
-  address: string;
-  detailAddress: string;
-  profileImage: string | undefined;
-}
 
 const DEFAULT_PROFILE_IMAGE = '/default-profile.png';
 

--- a/src/types/consumer.ts
+++ b/src/types/consumer.ts
@@ -159,3 +159,39 @@ export interface PointHistoryResponse {
   expiringPoints: number;
   history: PointHistory[];
 }
+
+/**
+ * 마이페이지 등에서 메뉴 버튼(아이템) 컴포넌트의 props 타입
+ */
+export interface MenuItemProps {
+  icon: React.ReactNode;
+  title: string;
+  onClick: () => void;
+}
+
+/**
+ * 도우미 선호도(찜/블랙리스트/선택없음) 타입
+ */
+export type PreferenceType = 'LIKE' | 'BLACKLIST' | 'NONE';
+
+/**
+ * 리뷰 등록 폼의 상태 타입
+ */
+export interface ReviewFormData {
+  rating: number;
+  comment: string;
+  preference: PreferenceType;
+}
+
+/**
+ * 소비자 프로필/프로필 수정 등에서 사용하는 사용자 정보 타입
+  */
+export interface ProfileData {
+  name: string;
+  phoneNumber: string;
+  birth: string;
+  gender: 'MALE' | 'FEMALE';
+  address: string;
+  detailAddress: string;
+  profileImage: string | undefined;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #93 

## 📝작업 내용

>
- ConsumerReviewRegister
- MyPage
- Proffile
- ProfileEdit
사용중인 인터페이스를 

src/types consumer.ts에 분리 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
