### PR TITLE
Refactor: consuemr 코드 분리

### DIFF
--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -43,3 +43,10 @@ export const SOCIAL_TYPE_LABELS = {
   [SOCIAL_TYPES.KAKAO]: '카카오',
   [SOCIAL_TYPES.GOOGLE]: '구글',
 } as const;
+
+
+/**
+ * 도우미 선호도(찜/블랙리스트/선택없음) 타입
+ */
+export type PreferenceType = 'LIKE' | 'BLACKLIST';
+

--- a/src/constants/user.ts
+++ b/src/constants/user.ts
@@ -44,7 +44,6 @@ export const SOCIAL_TYPE_LABELS = {
   [SOCIAL_TYPES.GOOGLE]: '구글',
 } as const;
 
-
 /**
  * 도우미 선호도(찜/블랙리스트/선택없음) 타입
  */

--- a/src/pages/consumer/MyPage.tsx
+++ b/src/pages/consumer/MyPage.tsx
@@ -14,8 +14,14 @@ import {
 } from 'lucide-react';
 import { useConsumer } from '@/hooks/domain/useConsumer';
 import { useToast } from '@/hooks/useToast';
-import type { ConsumerMyPageResponse, MenuItemProps } from '@/types/consumer';
+import type { ConsumerMyPageResponse } from '@/types/consumer';
 import { ROUTES } from '@/constants';
+
+interface MenuItemProps {
+  icon: React.ReactNode;
+  title: string;
+  onClick: () => void;
+}
 
 const MenuItem: React.FC<MenuItemProps> = ({ icon, title, onClick }) => (
   <button

--- a/src/types/consumer.ts
+++ b/src/types/consumer.ts
@@ -1,5 +1,5 @@
 import type { BaseUser } from './user';
-import type { Gender } from '@/constants/user';
+import type { Gender, PreferenceType} from '@/constants/user';
 
 /**
  * 소비자 프로필 생성 요청
@@ -160,19 +160,6 @@ export interface PointHistoryResponse {
   history: PointHistory[];
 }
 
-/**
- * 마이페이지 등에서 메뉴 버튼(아이템) 컴포넌트의 props 타입
- */
-export interface MenuItemProps {
-  icon: React.ReactNode;
-  title: string;
-  onClick: () => void;
-}
-
-/**
- * 도우미 선호도(찜/블랙리스트/선택없음) 타입
- */
-export type PreferenceType = 'LIKE' | 'BLACKLIST' | 'NONE';
 
 /**
  * 리뷰 등록 폼의 상태 타입
@@ -190,7 +177,7 @@ export interface ProfileData {
   name: string;
   phoneNumber: string;
   birth: string;
-  gender: 'MALE' | 'FEMALE';
+  gender: Gender;
   address: string;
   detailAddress: string;
   profileImage: string | undefined;


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #93 

## 📝작업 내용

>
- gender: 'MALE' | 'FEMALE';   -->  GENDER  상수를 쓰도록 변경
- export type PreferenceType = 'LIKE' | 'BLACKLIST' | 'NONE' --> 타입이 아닌 상수 폴더로 옮기기
- interface MenuItemProps --> 타입 폴더가 아닌 원래 사용하던 페이지로 옮기기


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
