### PR TITLE
feat: 포인트 조회 페이지 구현

### DIFF
--- a/src/apis/consumer/index.ts
+++ b/src/apis/consumer/index.ts
@@ -7,10 +7,24 @@ import type {
   BlackListedManagerResponse,
   PreferenceRequest,
   ConsumerProfileCreateRequest,
+  PointRecordResponseDto,
 } from '@/types/consumer';
 import { API_ENDPOINTS } from '@/constants/api';
 
 export const consumerApi = {
+/**
+ * 포인트 조회
+ */
+getPoint: async (): Promise<{ totalPoint: number }> => {
+  return apiCall<{ totalPoint: number }>('get', API_ENDPOINTS.CONSUMER.POINT);
+},
+
+/**
+ * 포인트 내역 조회 (post)
+ */
+getPointRecord: async (data: any): Promise<{ content: PointRecordResponseDto[]; hasNext: boolean }> => {
+  return apiCall<{ content: PointRecordResponseDto[]; hasNext: boolean }>('post', API_ENDPOINTS.CONSUMER.POINT_RECORD, data);
+},
   /**
    * 프로필 조회
    */

--- a/src/components/features/board/BoardForm.tsx
+++ b/src/components/features/board/BoardForm.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/useToast';
 import { useBoard } from '@/hooks/domain/useBoard';
 import { ROUTES } from '@/constants/route';

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -80,6 +80,8 @@ export const API_ENDPOINTS = {
     REVIEWS: '/api/manager/myReviews',
   },
   CONSUMER: {
+    POINT:'/api/point',
+    POINT_RECORD:'/api/point/record',
     PROFILE: '/api/consumers/profile',
     MYPAGE: '/api/consumers/mypage',
     LIKES: '/api/consumers/likes',

--- a/src/constants/route.ts
+++ b/src/constants/route.ts
@@ -18,6 +18,7 @@ export const ROUTES = {
     REVIEW_REGISTER: '/consumers/reservations/:id/review',
     LIKED_MANAGERS: '/consumer/likes',
     BLACKLIST: '/consumer/blacklist',
+    POINTS: '/consumer/points',
   },
 
   // 매니저 페이지

--- a/src/hooks/domain/usePoint.ts
+++ b/src/hooks/domain/usePoint.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from 'react';
+import { consumerApi } from '@/apis/consumer';
+import type { PointRecordResponseDto } from '@/types/consumer';
+
+export const usePoint = () => {
+  const [point, setPoint] = useState<number | null>(null);
+  const [history, setHistory] = useState<PointRecordResponseDto[]>([]);
+  const [hasNext, setHasNext] = useState<boolean>(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // 포인트 단일 조회
+  const fetchPoint = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await consumerApi.getPoint();
+      setPoint(res?.totalPoint ?? 0);
+    } catch (e: any) {
+      setError(e?.message || '포인트 조회 실패');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // 포인트 내역 조회
+  const fetchPointHistory = useCallback(async (body: any) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await consumerApi.getPointRecord(body);
+      setHistory(res.content ?? []);
+      setHasNext(res.hasNext ?? false);
+    } catch (e: any) {
+      setError(e?.message || '포인트 내역 조회 실패');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return {
+    point,
+    history,
+    hasNext,
+    loading,
+    error,
+    fetchPoint,
+    fetchPointHistory,
+  };
+}; 

--- a/src/pages/consumer/MyPage.tsx
+++ b/src/pages/consumer/MyPage.tsx
@@ -63,7 +63,7 @@ const MyPage: React.FC = () => {
   };
 
   const handlePoints = () => {
-    showToast('포인트 기능은 준비 중입니다.', 'info');
+    navigate(ROUTES.CONSUMER.POINTS);
   };
 
   const handleLikedManagers = () => {

--- a/src/pages/consumer/PointsPage.tsx
+++ b/src/pages/consumer/PointsPage.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState } from 'react';
+import { Header } from '@/components/layout/Header/Header';
+import { ROUTES } from '@/constants';
+import { Coins } from 'lucide-react';
+import { usePoint } from '@/hooks/domain/usePoint';
+
+const PAGE_SIZE = 5;
+
+const PointsPage: React.FC = () => {
+  const { point, history, hasNext, loading, error, fetchPoint, fetchPointHistory } = usePoint();
+  const [monthOffset, setMonthOffset] = useState(0);
+  const [page, setPage] = useState(0);
+  const [allLoaded, setAllLoaded] = useState(false);
+  const [list, setList] = useState<typeof history>([]);
+
+  // 현재 월 계산
+  const getMonthLabel = (offset: number) => {
+    const now = new Date();
+    now.setMonth(now.getMonth() + offset);
+    return `${now.getFullYear()}년 ${now.getMonth() + 1}월`;
+  };
+
+  // 월이 바뀌면 페이지/리스트 초기화
+  useEffect(() => {
+    setPage(0);
+    setList([]);
+    setAllLoaded(false);
+  }, [monthOffset]);
+
+  // 포인트 조회(최초 1회)
+  useEffect(() => {
+    fetchPoint();
+  }, [fetchPoint]);
+
+  // 페이지/월 변경 시 내역 불러오기
+  useEffect(() => {
+    fetchPointHistory({
+      monthOffset,
+      pointType: 'ALL',
+      pageable: {
+        page,
+        size: PAGE_SIZE,
+        sort: [
+          { property: 'createdAt', direction: 'DESC' },
+        ],
+      },
+    });
+  }, [monthOffset, page, fetchPointHistory]);
+
+  // history가 바뀔 때 리스트 누적/마지막 페이지 체크
+  useEffect(() => {
+    if (page === 0) {
+      setList(history);
+    } else if (history.length > 0) {
+      setList((prev) => [...prev, ...history]);
+    }
+    // hasNext로 마지막 페이지 판단
+    setAllLoaded(!hasNext);
+  }, [history, page, hasNext]);
+
+  const handleLoadMore = () => {
+    setPage((prev) => prev + 1);
+  };
+
+  // 월 변경 핸들러 (1년 범위 제한)
+  const handlePrevMonth = () => {
+    if (monthOffset > -11) setMonthOffset((prev) => prev - 1);
+  };
+  const handleNextMonth = () => {
+    if (monthOffset < 0) setMonthOffset((prev) => prev + 1);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 pt-20">
+      <Header
+        variant="sub"
+        title="내 포인트"
+        backRoute={ROUTES.CONSUMER.MYPAGE}
+        showMenu={false}
+      />
+      <div className="px-4 pb-6 max-w-md mx-auto">
+        <div className="bg-white rounded-xl shadow-sm p-6 mb-6 text-center">
+          <div className="flex flex-col items-center gap-2 mb-4">
+            <Coins className="w-10 h-10 text-[#FF6B00]" />
+            <span className="text-gray-600">내 포인트</span>
+            <span className="text-2xl font-bold text-[#FF6B00]">{point !== null ? point.toLocaleString() : '-'}P</span>
+          </div>
+        </div>
+        <div className="bg-white rounded-xl shadow-sm p-6">
+          <div className="flex items-center justify-between mb-4">
+            {/* 이전달 버튼 */}
+            <button
+              className={`px-2 py-1 min-w-[40px] rounded-md text-lg font-medium transition-colors
+                ${monthOffset <= -11 ? 'text-gray-300 bg-transparent border-none' : 'text-[#FF6B00] border-transparent bg-white hover:bg-orange-50 border'}
+              `}
+              onClick={handlePrevMonth}
+              disabled={monthOffset <= -11}
+              aria-label="이전달"
+            >
+              ◀
+            </button>
+            <span className="font-semibold text-gray-800">{getMonthLabel(monthOffset)}</span>
+            {/* 다음달 버튼 */}
+            <button
+              className={`px-2 py-1 min-w-[40px] rounded-md text-lg font-medium transition-colors
+                ${monthOffset >= 0 ? 'text-gray-300 bg-transparent border-none' : 'text-[#FF6B00] border-transparent bg-white hover:bg-orange-50 border'}
+              `}
+              onClick={handleNextMonth}
+              disabled={monthOffset >= 0}
+              aria-label="다음달"
+            >
+              ▶
+            </button>
+          </div>
+          <h3 className="text-lg font-semibold mb-4">포인트 내역</h3>
+          {loading && page === 0 ? (
+            <div className="text-gray-400 text-center py-8">로딩 중...</div>
+          ) : error ? (
+            <div className="text-red-400 text-center py-8">{error}</div>
+          ) : list.length === 0 ? (
+            <div className="text-gray-400 text-center py-8">해당 월의 포인트 내역이 없습니다.</div>
+          ) : (
+            <>
+              <ul className="divide-y divide-gray-100">
+                {list.map((item, idx) => (
+                  <li key={idx} className="flex justify-between items-center py-3">
+                    <div>
+                      <div className="text-gray-900 font-medium">{item.description}</div>
+                      <div className="text-xs text-gray-400">{item.createdAt ? new Date(item.createdAt).toLocaleDateString() : '-'}</div>
+                    </div>
+                    <div className={item.amount > 0 ? 'text-[#FF6B00] font-bold' : 'text-gray-400 font-bold'}>
+                      {item.amount > 0 ? `+${item.amount.toLocaleString()}` : item.amount.toLocaleString()}P
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              {!allLoaded && (
+                <button
+                  className="w-full mt-4 py-2 bg-[#FF6B00] rounded text-white font-semibold hover:bg-[#FF8533] transition-colors"
+                  onClick={handleLoadMore}
+                  disabled={loading}
+                >
+                  {loading ? '불러오는 중...' : '더보기'}
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PointsPage; 

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -47,6 +47,9 @@ export { default as LikedManagerList } from './consumer/LikedManagerList';
 // 수요자의 블랙리스트 매니저 조회
 export { default as BlackListManagerList } from './consumer/BlackListManagerList';
 
+// 소비자 포인트 페이지
+export { default as PointsPage } from './consumer/PointsPage';
+
 /**
  * manager
  */

--- a/src/routes/consumer.tsx
+++ b/src/routes/consumer.tsx
@@ -12,6 +12,7 @@ import {
   ConsumerReviewRegister,
   LikedManagerList,
   BlackListManagerList,
+  PointsPage,
 } from '@/pages';
 import GoogleMap from '@/pages/reservation/GoogleMap';
 import { Status, Wrapper } from '@googlemaps/react-wrapper';
@@ -116,6 +117,14 @@ export const ConsumerRoutes = () => (
       element={
         <ProtectedRoute requiredUserType="CONSUMER">
           <BlackListManagerList />
+        </ProtectedRoute>
+      }
+    />
+    <Route
+      path={ROUTES.CONSUMER.POINTS}
+      element={
+        <ProtectedRoute requiredUserType="CONSUMER">
+          <PointsPage />
         </ProtectedRoute>
       }
     />

--- a/src/types/consumer.ts
+++ b/src/types/consumer.ts
@@ -163,7 +163,6 @@ export interface PointHistoryResponse {
   history: PointHistory[];
 }
 
-
 /**
  * 리뷰 등록 폼의 상태 타입
  */
@@ -184,3 +183,10 @@ export interface ProfileData {
   detailAddress: string;
   profileImage: string | undefined;
 }
+export interface PointRecordResponseDto {
+  amount: number;
+  pointType: string;
+  description: string;
+  createdAt: string;
+}
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #160 

## 📝작업 내용

> 포인트 조회 페이지 구현 
- 토탈 포인트 조회
- 포인트 적립 내역 조회 
-- 현재 속한 날짜의 달을 기준으로 보여주고 있음
-- 페이지네이션 적용 5개 기준 - 더보기 버튼 클릭시 추가로 보여줌(5개씩)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
