### PR TITLE
refactor: board 삭제시 토스트 메시지 정상화

### DIFF
--- a/src/pages/board/BoardList.tsx
+++ b/src/pages/board/BoardList.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { MessageSquare } from 'lucide-react';
 import { useBoard } from '@/hooks/domain/useBoard';
 import { ROUTES } from '@/constants/route';
@@ -7,14 +7,26 @@ import type { BoardResponse } from '@/types/domain/board';
 import BoardItem from '@/components/features/board/BoardItem';
 import { usePagination } from '@/hooks';
 import { Header } from '@/components/layout/Header/Header';
+import { useToast } from '@/hooks/useToast';
 
 export default function BoardList() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { showToast } = useToast();
   const { boards, loading: isLoading, fetchBoards } = useBoard();
 
   useEffect(() => {
     fetchBoards();
   }, [fetchBoards]);
+
+  useEffect(() => {
+    if (location.state && location.state.toast) {
+      const { message, type } = location.state.toast;
+      showToast(message, type);
+      // 히스토리 state 초기화 (중복 방지)
+      window.history.replaceState({}, document.title);
+    }
+  }, [location.state, showToast]);
 
   const handleCreate = () => {
     navigate(ROUTES.BOARD.CREATE);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #214 

## 📝작업 내용

> 
- 게시판 삭제시 한번 더 게시판을 조회하는 현상이 발생해 에러 알림이 함께 나타나는 현상 발생
- 게시글 정상 삭제 되었다는 알림 메시지만 나오게 로직 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
